### PR TITLE
Fix VarCo export

### DIFF
--- a/Lib/rcjktools/objects.py
+++ b/Lib/rcjktools/objects.py
@@ -6,7 +6,7 @@ from fontTools.pens.filterPen import FilterPointPen
 from fontTools.pens.pointPen import PointToSegmentPen, SegmentToPointPen
 from fontTools.pens.recordingPen import RecordingPointPen
 from fontTools.ufoLib.glifLib import readGlyphFromString
-from fontTools.varLib.models import normalizeLocation
+from fontTools.varLib.models import normalizeValue
 
 
 logger = logging.getLogger(__name__)
@@ -139,6 +139,17 @@ class Glyph(_MathMixin):
             for compo1, compo2 in zip(self.components, other.components)
         ]
         return result
+
+
+def normalizeLocation(location, axes):
+    """This behaves different from varLib.models.normalizeLocation in that
+    it won't add missing axes values and doesn't filter values that aren't
+    in the axes dict.
+    """
+    return {
+        axisName: normalizeValue(v, axes.get(axisName, (-1, 0, 1)))
+        for axisName, v in location.items()
+    }
 
 
 class Component(NamedTuple):

--- a/Lib/rcjktools/project.py
+++ b/Lib/rcjktools/project.py
@@ -363,7 +363,7 @@ def buildVarCoDesignSpaceDocument(ufo, ufoPath, axes, axisNames):
         assert axisName.startswith("V")
         assert len(axisName) == 4
         doc.addAxisDescriptor(
-            name=axisName, tag=axisName, minimum=0, default=0, maximum=1, hidden=True
+            name=axisName, tag=axisName, minimum=-1, default=0, maximum=1, hidden=True
         )
     return doc
 

--- a/Lib/rcjktools/varco.py
+++ b/Lib/rcjktools/varco.py
@@ -73,7 +73,7 @@ class VarCoGlyph(Glyph):
                 if self.name not in ufo:
                     continue
                 for axisName, axisValue in location.items():
-                    assert 0 <= axisValue <= 1, (axisName, axisValue)
+                    assert -1 <= axisValue <= 1, (axisName, axisValue)
                 varGlyph = self.__class__.loadFromGlyphObject(ufo[self.name])
                 varGlyph._postParse([], [])
                 varGlyph.location = location


### PR DESCRIPTION
Adapt VarCo export code to support rcjk's new-ish defaultValue addition, which makes the internal VarCo axis ranges go from -1 to 1 instead of 0 to 1.

This also partially revert recent normalizing changes